### PR TITLE
bugfix: fix regex for linux /dev/tty* devices

### DIFF
--- a/zahner_potentiostat/scpi_control/searcher.py
+++ b/zahner_potentiostat/scpi_control/searcher.py
@@ -252,7 +252,7 @@ class SCPIDeviceSearcher():
             ports = ["COM%s" % (i + 1) for i in range(256)]
         elif sys.platform.startswith("linux") or sys.platform.startswith("cygwin"):
             # this excludes your current terminal "/dev/tty"
-            ports = glob.glob("/dev/tty[A-Za-z]*")
+            ports = glob.glob("/dev/tty[A-Za-z]+[A-Za-z0-9]*")
         elif sys.platform.startswith("darwin"):
             ports = glob.glob("/dev/tty.*")
         else:


### PR DESCRIPTION
The old regex does not include numbers and it also includes `/dev/tty` which should probably be excluded.