### PR TITLE
bugfix: remove win32 specialization from serial library import

### DIFF
--- a/zahner_potentiostat/scpi_control/searcher.py
+++ b/zahner_potentiostat/scpi_control/searcher.py
@@ -28,7 +28,7 @@ import glob
 import sys
 import time
 
-from serial.serialwin32 import Serial
+from serial import Serial
 import serial.tools.list_ports
 
 


### PR DESCRIPTION
The change says it all.