### PR TITLE
add dependencies to setup.py (fixes #3)

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -41,4 +41,5 @@ setuptools.setup(
     ],
     python_requires=">=3.9",
     platforms="any",
+    install_requires=["matplotlib", "pyserial", "numpy"],
 )


### PR DESCRIPTION
The `pip install` output includes dependencies now which it previously did not:

```text
$ pip3 install dist/zahner_potentiostat-1.0.8-py3-none-any.whl 
Processing ./dist/zahner_potentiostat-1.0.8-py3-none-any.whl
Requirement already satisfied: matplotlib in /home/user/.local/lib/python3.9/site-packages (from zahner-potentiostat==1.0.8) (3.6.2)
Requirement already satisfied: pyserial in /home/user/.local/lib/python3.9/site-packages (from zahner-potentiostat==1.0.8) (3.5)
Requirement already satisfied: numpy in /home/user/.local/lib/python3.9/site-packages (from zahner-potentiostat==1.0.8) (1.23.4)
Requirement already satisfied: kiwisolver>=1.0.1 in /home/user/.local/lib/python3.9/site-packages (from matplotlib->zahner-potentiostat==1.0.8) (1.4.4)
Requirement already satisfied: pyparsing>=2.2.1 in /home/user/.local/lib/python3.9/site-packages (from matplotlib->zahner-potentiostat==1.0.8) (3.0.9)
Requirement already satisfied: fonttools>=4.22.0 in /home/user/.local/lib/python3.9/site-packages (from matplotlib->zahner-potentiostat==1.0.8) (4.38.0)
Requirement already satisfied: python-dateutil>=2.7 in /home/user/.local/lib/python3.9/site-packages (from matplotlib->zahner-potentiostat==1.0.8) (2.8.2)
Requirement already satisfied: contourpy>=1.0.1 in /home/user/.local/lib/python3.9/site-packages (from matplotlib->zahner-potentiostat==1.0.8) (1.0.6)
Requirement already satisfied: packaging>=20.0 in /home/user/.local/lib/python3.9/site-packages (from matplotlib->zahner-potentiostat==1.0.8) (21.3)
Requirement already satisfied: pillow>=6.2.0 in /usr/lib/python3/dist-packages (from matplotlib->zahner-potentiostat==1.0.8) (8.1.2)
Requirement already satisfied: cycler>=0.10 in /home/user/.local/lib/python3.9/site-packages (from matplotlib->zahner-potentiostat==1.0.8) (0.11.0)
Requirement already satisfied: six>=1.5 in /usr/lib/python3/dist-packages (from python-dateutil>=2.7->matplotlib->zahner-potentiostat==1.0.8) (1.16.0)
Installing collected packages: zahner-potentiostat
Successfully installed zahner-potentiostat-1.0.8
```